### PR TITLE
Handle datetimes that use a - instead of T

### DIFF
--- a/src/zeep/xsd/types/builtins.py
+++ b/src/zeep/xsd/types/builtins.py
@@ -170,13 +170,14 @@ class DateTime(BuiltinType):
 
     @treat_whitespace("collapse")
     def pythonvalue(self, value):
-
         # Determine based on the length of the value if it only contains a date
         # lazy hack ;-)
         if len(value) == 10:
             value += "T00:00:00"
         elif (len(value) == 19 or len(value) == 26) and value[10] == " ":
             value = "T".join(value.split(" "))
+        elif len(value) > 10 and value[10] == "-":  # 2010-01-01-00:00:00...
+            value[10] = "T"
         return isodate.parse_datetime(value)
 
 

--- a/tests/test_xsd_builtins.py
+++ b/tests/test_xsd_builtins.py
@@ -197,6 +197,9 @@ class TestDateTime:
         value = datetime.datetime(2016, 3, 4, 0, 0, 0)
         assert instance.pythonvalue(" \r\n\t2016-03-04   ") == value
 
+        value = datetime.datetime(2016, 3, 4, 21, 14, 42, 123456)
+        assert instance.pythonvalue("2016-03-04-21:14:42.123456") == value
+
     def test_pythonvalue_invalid(self):
         instance = builtins.DateTime()
         with pytest.raises(ValueError):


### PR DESCRIPTION
Makes "2016-03-04-21:14:42.123456" parsable